### PR TITLE
FBX Importの修正　＆　 msJobPitcherのプロジェクトを設定する部分の追記

### DIFF
--- a/importScenes.py
+++ b/importScenes.py
@@ -1,6 +1,7 @@
 import maya.cmds as mc
 import os.path
 import logging
+import maya.mel as mel
 
 def importScenes():
     logging.debug('importScens')
@@ -10,6 +11,7 @@ def importScenes():
     fName = os.path.basename(fPath)
     root, ext = os.path.splitext(fPath)
     nSpace = fName.replace(ext, "")
+    fbxFPath = fPath.replace("\\","/")
 
     if ext == ".ma":
         ftype = "mayaAscii"
@@ -18,7 +20,8 @@ def importScenes():
         ftype = "mayaBinary"
 
     elif ext == ".fbx":
-        ftype = "Fbx"
+        mel.eval('FBXImport -f "{} ;'.format(fbxFPath))
+        return
 
     elif ext == ".obj":
         ftype = "OBJ"

--- a/msJobPitcher.py
+++ b/msJobPitcher.py
@@ -1,6 +1,7 @@
 # coding:UTF-8
 import Ui
 import logging
+import maya.mel as mel
 
 def develop():
     reload(Ui)
@@ -9,5 +10,7 @@ def develop():
 def execution():
     develop()
     logging.debug('excution msJobPitcher')
+
+    mel.eval('setProject "//172.29.44.4/cg/ms06/renderProJ" ;')
 
     Ui.ui()


### PR DESCRIPTION
FBX Import時のウィンドウを開かないように。
msJobPitcherのプロジェクトを設定する部分の追記。

プロジェクト設定とFBXImportがどうやらMelのコマンドオンリーのようだったので
import maya.mel as mel をインポートしています。