### PR TITLE
getTimerange関数の追加

### DIFF
--- a/timerange.py
+++ b/timerange.py
@@ -1,0 +1,43 @@
+import maya.cmds as mc
+import csv
+
+csvPath = '/Users/ryota/Documents/python/timerange.csv'
+
+def getTimerange():
+    f = open(csvPath, 'r')
+    # print f
+    x = 0
+    shotID = "s15c02"
+    timeShotID = ""
+    timeStart = 0
+    timeEnd = 0
+
+    reader = csv.reader(f)
+    # header = next(reader)
+    for row in reader:
+        # print row
+        if shotID in row:
+            timeShotID = row[0]
+            timeStart = row[2]
+            timeEnd = row[3]
+            
+            if row[2] == '' or row[3] == '':
+                timeStart = 0
+                timeEnd = 0
+                print "show CSV File ==>> {}".format(csvPath)
+                break
+
+    f.close()
+
+    return [timeStart,timeEnd]
+
+    # setTimeRange.....
+    # mc.setAttr('defaultRenderGlobals.startFrame', timeStart)
+    # mc.setAttr('defaultRenderGlobals.endFrame', timeEnd)
+
+mc.window(title='test', w=200)
+mc.columnLayout(adj=True)
+mc.button( label = 'csvTest', w=100, h=40, command='getTimerange()')
+
+mc.showWindow()
+


### PR DESCRIPTION
getTimerange関数の追加をして、戻り値を[StartFrame,EndFrame]にしました。


    # setTimeRange.....
    # mc.setAttr('defaultRenderGlobals.startFrame', timeStart)
    # mc.setAttr('defaultRenderGlobals.endFrame', timeEnd)
のコメントアウトを解除するとレンダー設定に取得したStartFrame、EndFrameを挿入します。
これを設定する際は、上書き防止のため、renderSetting.pyの
    # mc.setAttr('defaultRenderGlobals.startFrame', )
    # mc.setAttr('defaultRenderGlobals.endFrame', )
部分の削除をお願いします。

単体で検証するためにWINDOW部分を入れてあります。

